### PR TITLE
Adding JSONB formatting for objects

### DIFF
--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -30,6 +30,12 @@ module.exports = class extends Default {
 
     for (let attributeName of Object.keys(joiSchema)) {
       const attribute = joiSchema[attributeName];
+      if (attribute._type === 'object') {
+        this[attributeName] = {
+          type: DataTypes.JSONB,
+          allowNull: true
+        }
+      }
       if (attribute._type === 'number') {
         if (typeof attribute._flags.precision !== 'undefined') {
           this[attributeName] = {


### PR DESCRIPTION
Hi guys, please let me know if you think this is a bad idea, I have confirmed that this works on my local setup when my resource looks like this:
```
attributes: {
    id: jsonApi.Joi.string(),
    payload: jsonApi.Joi.object(),
    source: jsonApi.Joi.string(),
    type: jsonApi.Joi.string(),
  },
```
When the table gets created, the `payload` property is created as a JSONB format.